### PR TITLE
Update package.json for using the right cli arch while building electron-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/DeFiCh/app",
   "publicPath": "./",
   "config": {
-    "ainVersion": "4.1.0"
+    "ainVersion": "4.1.1"
   },
   "scripts": {
     "init": "npm ci --force && cd webapp && npm run init",
@@ -29,12 +29,16 @@
     "pre:build:linux": "node ./scripts/prebuild linux",
     "pre:build:mac": "node ./scripts/prebuild mac",
     "pre:build:win": "node ./scripts/prebuild win",
+    "pre:build:arm-linux": "node ./scripts/prebuild arm-linux",
+    "pre:build:arm-mac": "node ./scripts/prebuild arm-mac", 
     "build:electron": "npm run build:react && npm run transpile:prod && npm run set_env:prod",
     "build": "npm run build:electron && electron-builder",
     "build:all": "npm run build:electron && electron-builder -mwl",
-    "build:linux": "npm run pre:build:linux && npm run build:electron && electron-builder --linux -p never",
-    "build:mac": "npm run pre:build:mac && npm run build:electron && electron-builder --mac --x64 --arm64 -p never",
+    "build:linux": "npm run pre:build:linux && npm run build:electron && electron-builder --linux appimage:x64-p never",
+    "build:mac": "npm run pre:build:mac && npm run build:electron && electron-builder --mac dwg:x64 -p never",
     "build:win": "npm run pre:build:win && npm run build:electron && electron-builder --win -p never",
+    "build:arm-linux": "npm run pre:build:arm-linux && npm run build:electron && electron-builder --linux appimage:arm64 -p never",
+    "build:arm-mac": "npm run pre:build:arm-mac && npm run build:electron && electron-builder --mac dmg:arm64 -p never",   
     "pack": "npm run build:electron && electron-builder --dir",
     "postinstall": "electron-builder install-app-deps",
     "publish": "npm run build:react && npm run transpile:prod && npm run set_env:prod && electron-builder build -p always",
@@ -112,7 +116,7 @@
     "typescript": "^4.6.3"
   },
   "build": {
-    "productName": "DeFi Wallet",
+    "productName": "DeFi-Wallet",
     "appId": "com.defichain.DeFiWallet",
     "copyright": "Copyright © 2020-2023 ${author}",
     "asar": true,
@@ -163,12 +167,7 @@
     },
     "mac": {
       "category": "public.app-category.finance",
-      "target": [
-        {
-          "target": "dmg",
-          "arch": ["x64", "arm64", "universal"]
-        }
-      ],
+      "target": ["dmg"],
       "mergeASARs": true,
       "x64ArchFiles": "*",
       "type": "distribution",


### PR DESCRIPTION
I recognized a problem while using the "arch": ["x64", "arm64", "universal"] in package.json for electron-app. I don't think it uses the different cli arch for building the different electron-app arch. I think it must be selected from ../scripts/prebuild.js -> x64 cli for x64 desktop app and arm cli for arm desktop app. -> changes of prebuild.js follows...

Pardon me, if my changes coming the wrong way - it's my first time to change scripts by using a fork of a repository...

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:
It compares the cli arch with the same arch of the electron-builder

#### Which issue(s) does this PR fixes?:
While using PC with x64 or arm64 architecture the running cli must be the same as the desktop-app is.

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
This PR goes together with the changes in "../scripts/prebuild.js"