### PR TITLE
Update prebuild.js for using the right cli arch while building electron-app

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -9,7 +9,7 @@ async function main() {
   const rootDir = path.dirname(__dirname);
   const distDir = path.join(rootDir, 'dist');
   const tempDir = path.join(distDir, 'temp');
-  const platforms = ['linux', 'mac', 'win'];
+  const platforms = ['linux', 'mac', 'win', 'arm-linux', 'arm-mac'];
 
   const binDirs = new Map();
   platforms.forEach((platform) =>
@@ -121,6 +121,10 @@ function getPlatformUrlSuffix(platform) {
       return 'x86_64-apple-darwin.tar.gz';
     case 'win':
       return 'x86_64-w64-mingw32.zip';
+    case 'arm-linux':
+      return 'aarch64-linux-gnu.tar.gz';
+    case 'arm-mac':
+      return 'aarch64-apple-darwin.tar.gz';
     default:
       throw new Error('invalid platform');
   }
@@ -137,6 +141,17 @@ function processPlatformArg(arg) {
     case 'mac':
     case 'darwin':
       return 'mac';
+    case 'arm-linux':
+    case 'arm64-linux':
+    case 'aarch64-linux':
+    case 'arm':
+    case 'arm64':
+    case 'aarch64':
+      return 'arm-linux';
+    case 'arm-mac':
+    case 'arm64-mac':
+    case 'aarch64-mac':
+      return 'arm-mac';
     default:
       throw new Error('invalid platform arg');
   }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:
It compares the cli arch with the same arch of the electron-builder

#### Which issue(s) does this PR fixes?:
While using PC with x64 or arm64 architecture the running cli must be the same as the desktop-app is.

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
This PR comes together with the changes in "packages.json"